### PR TITLE
Run the agent process as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ EXPOSE 8707
 
 RUN apk add --no-cache curl
 
-ADD blackfire blackfire-agent /usr/bin/
+COPY blackfire blackfire-agent /usr/local/bin/
+
+# Don't run as root
+RUN addgroup -S blackfire && adduser -S -H -G blackfire -u 999 blackfire
+USER blackfire
 
 CMD ["blackfire-agent"]


### PR DESCRIPTION
In kubernetes clusters is common to enable pod security policies, that disallow containers that run the main process as root, because hackers can gain root access to the Docker host by hacking the application running inside the container.

With this PR the blackfire agent runs as an unprivileged user.